### PR TITLE
Implement doOptions for CORS

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
@@ -179,6 +179,15 @@ public class MetricsServlet extends HttpServlet {
             output.close();
         }
     }
+    
+    @Override
+    protected void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        // Send Response
+        super.doOptions(req,  resp);
+        if (allowedOrigin != null) {
+            resp.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+        }
+    }
 
     private ObjectWriter getWriter(HttpServletRequest request) {
         final boolean prettyPrint = Boolean.parseBoolean(request.getParameter("pretty"));


### PR DESCRIPTION
Set Access-Control-Allow-Origin on Options response headers if allowedOrigin is specified by a ContextListener.